### PR TITLE
[SCHEDULER-16] Фикс ручного создания будущих записей

### DIFF
--- a/src/main/kotlin/com/funnco/schedulerbackend2/resource/ScheduleResource.kt
+++ b/src/main/kotlin/com/funnco/schedulerbackend2/resource/ScheduleResource.kt
@@ -100,7 +100,7 @@ class ScheduleResource {
 
     @PostMapping("/force/create_new")
     fun forceUpdateNew(){
-        currentEventsService.forceCreateFutureEventsByTemplate(3)
+        currentEventsService.forceCreateFutureEventsByTemplate(4)
     }
 
     @DeleteMapping("/force/delete_future")

--- a/src/main/kotlin/com/funnco/schedulerbackend2/service/CurrentEventsService.kt
+++ b/src/main/kotlin/com/funnco/schedulerbackend2/service/CurrentEventsService.kt
@@ -140,8 +140,9 @@ class CurrentEventsService {
         try {
             log.info("[$className] Start forcefully creating new notes from all templates (weeks: ${weeks})")
             val allTemplates = templateEventsRepository.findAll().toList()
-            for (currentWeekOffset in 1..weeks) {
+            for (currentWeekOffset in 0..weeks) {
                 val newEvents = allTemplates.stream()
+                    .filter { template -> template.weekDay!!.ordinal > LocalDate.now().dayOfWeek.ordinal || currentWeekOffset > 0}
                     .map { template -> mapTemplateToEvent(template, currentWeekOffset.toLong()) }
                     .toList()
                 currentEventsRepository.saveAll(newEvents)


### PR DESCRIPTION
Фикс, чтобы записи создавались и на текущей неделе + фикс отсутствия генерации 4 недели, из-за чего при автогенерации пропускалась неделя